### PR TITLE
Add support files template

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,7 @@
   * [Integrating with Auth](tutorials/auth.md)
 
 ## Advanced Concepts
-  * [Something Advanced](advanced-topics/advanced-topic-1.md) 
+  * [Something Advanced](advanced-topics/advanced-topic-1.md)
 
 ## Join The Community
   * [Help, feedback, & discussion](Community.md)
@@ -23,3 +23,6 @@
   * [API Reference](api-reference/api-1.md)
   * [Release Notes](RELEASENOTES.md)
 
+## Support
+  * [Overview](support/README.md)
+  * [FAQ](support/faq/README.md)

--- a/support/README.md
+++ b/support/README.md
@@ -1,0 +1,15 @@
+# Support
+
+Learn where to ask questions, report bugs, make feature requests, and spark discussions.
+
+## [FAQ](./faq/README.md)
+
+A knowledge base of frequently asked questions. This is a great starting place to find an answer before asking your question.
+
+## [GitHub Issues](https://github.com/AdobeDocs/YOUR-PROJECT-NAME/issues)
+
+This is the place to report bugs, ask questions, make feature requests, or start a discussion. You'll find official Adobe developers and community members available to help you out.
+
+## [Stack Overflow](https://stackoverflow.com/questions/tagged/YOUR-TAG-NAME)
+
+Ask questions and find answers from our developer community using the **YOUR-TAG-NAME** tag.

--- a/support/faq/README.md
+++ b/support/faq/README.md
@@ -1,0 +1,7 @@
+# Frequently Asked Questions
+
+- [Title of a question?](#title-of-a-question)
+
+### Title of a question?
+
+This is the answer to the question.


### PR DESCRIPTION
## Description

This pull request adds a template for the support files. It includes an **Overview** section that lists the product's support channels and a **FAQ** section for answers to common questions.

**A question for the reviewer**: Would you prefer the `faq/` directory to be top-level or nested under `support/faq`? I chose the nesting to preserve the support context and keep the top-level clean.

## Motivation and Context

The motivation is to improve the support model used by the Adobe Developer website. Today all support is routed through a common help desk and triaged to the appropriate team. This triage step is slow and opaque to the end-developer. This pull request exposes the product team's support channels to the end-developer, so that they can ask the question directly. This removes the triage step and takes the end-developer one step closer to the product's engineering team.

## How Has This Been Tested?

Tested by browser files on github.com

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
